### PR TITLE
basic fixes: typo, broken links, missing hyperlinks

### DIFF
--- a/docs/src/crit-guide/system-requirements.md
+++ b/docs/src/crit-guide/system-requirements.md
@@ -16,6 +16,6 @@ _Newer versions of the kernel will enable using cilium's kube-proxy replacement 
 
 ### References
 
- * https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/#cni
- * https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/#support-hostport
- * https://docs.cilium.io/en/v1.6/gettingstarted/cni-chaining-portmap/#portmap-hostport
+ * [https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/#cni](https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/#cni)
+ * [https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/#support-hostport](https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/#support-hostport)
+ * [https://docs.cilium.io/en/v1.6/gettingstarted/cni-chaining-portmap/#portmap-hostport](https://docs.cilium.io/en/v1.6/gettingstarted/cni-chaining-portmap/#portmap-hostport)

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -10,7 +10,7 @@ $ cinder create cluster
 
 This quickly creates a ready-to-use Kubernetes cluster running completely within a single Docker container.
 
-Cinder, or Crit-in-Docker, can be useful for developing on Critial Stack clusters locally, or simply to learn more about Crit. You can read more about requirements, configuration, etc over in the [Cinder Guide](cinder-guide/overview.md).
+Cinder, or Crit-in-Docker, can be useful for developing on Critical Stack clusters locally, or simply to learn more about Crit. You can read more about requirements, configuration, etc over in the [Cinder Guide](cinder-guide/overview.md).
 
 ## Running in Production
 

--- a/docs/src/security-guide/overview.md
+++ b/docs/src/security-guide/overview.md
@@ -2,9 +2,9 @@
 
 This guide will take you through configuring security features of Kubernetes, as well as, features specific to Crit. It will also include general helpful information or gotchas to look out for when creating a new cluster.
 
-- [Encrypting Kubernetes Secrets](security-guide/encrypting-kubernetes-secrets.md)
-- [Enabling Pod Security Policies](security-guide/enabling-pod-security-policies.md)
-- [Audit Policy Logging](security-guide/audit-policy-logging.md)
-- [Disabling Anonymous Authentication](security-guide/disabling-anonymous-authentication.md)
-- [Kubelet Server Certificate](security-guide/kubelet-server-certificate.md)
-- [Encrypting Shared Cluster Files](security-guide/encrypting-shared-cluster-files.md)
+- [Encrypting Kubernetes Secrets](encrypting-kubernetes-secrets.md)
+- [Enabling Pod Security Policies](enabling-pod-security-policies.md)
+- [Audit Policy Logging](audit-policy-logging.md)
+- [Disabling Anonymous Authentication](disabling-anonymous-authentication.md)
+- [Kubelet Server Certificate](kubelet-server-certificate.md)
+- [Encrypting Shared Cluster Files](encrypting-shared-cluster-files.md)


### PR DESCRIPTION
Basic fixes: 
1) Typo - "Critial Stack" : https://docs.crit.sh/getting-started.html#quick-start
2) `References` are not hyperlinked: https://docs.crit.sh/crit-guide/system-requirements.html#references
3) Links on the Security Guide overview page are broken: https://docs.crit.sh/security-guide/overview.html