### PR TITLE
cinder: update mapi and mapd

### DIFF
--- a/build/images/node/Makefile
+++ b/build/images/node/Makefile
@@ -30,8 +30,8 @@ KUBERNETES_VERSION    := 1.18.5
 CHARTS_DIR                          := $(PWD)/charts
 CILIUM_VERSION                      := 1.8.1
 LOCAL_PATH_PROVISIONER_VERSION      := 0.0.12
-MACHINE_API_VERSION                 := 0.1.2
-MACHINE_API_PROVIDER_DOCKER_VERSION := 0.1.2
+MACHINE_API_VERSION                 := 1.0.1
+MACHINE_API_PROVIDER_DOCKER_VERSION := 1.0.2
 
 charts/*.tgz:
 	mkdir -p $(CHARTS_DIR)
@@ -44,12 +44,8 @@ charts/*.tgz:
 	helm repo update
 	helm pull cilium/cilium --version $(CILIUM_VERSION) -d $(CHARTS_DIR)
 	helm pull criticalstack/local-path-provisioner --version $(LOCAL_PATH_PROVISIONER_VERSION) -d $(CHARTS_DIR)
-	helm pull criticalstack/machine-api --version $(MACHINE_API_VERSION) -d $(CHARTS_DIR)
-	helm pull criticalstack/machine-api-provider-docker --version $(MACHINE_API_PROVIDER_DOCKER_VERSION) -d $(CHARTS_DIR)
 	mv $(CHARTS_DIR)/cilium-$(CILIUM_VERSION).tgz $(CHARTS_DIR)/cilium.tgz
 	mv $(CHARTS_DIR)/local-path-provisioner-$(LOCAL_PATH_PROVISIONER_VERSION).tgz $(CHARTS_DIR)/local-path-provisioner.tgz
-	mv $(CHARTS_DIR)/machine-api-$(MACHINE_API_VERSION).tgz $(CHARTS_DIR)/machine-api.tgz
-	mv $(CHARTS_DIR)/machine-api-provider-docker-$(MACHINE_API_PROVIDER_DOCKER_VERSION).tgz $(CHARTS_DIR)/machine-api-provider-docker.tgz
 
 build/*.tar:
 	mkdir -p $(BUILD_DIR)
@@ -67,7 +63,11 @@ build: clean $(CRIT) $(CINDER) charts/*.tgz build/*.tar ## build cinder docker i
 	docker exec $(BUILD_CONTAINER_NAME) bash -c 'mkdir -p /cinder'
 	docker cp ./charts $(BUILD_CONTAINER_NAME):/cinder/charts
 	docker cp ./scripts $(BUILD_CONTAINER_NAME):/cinder/scripts
-	docker exec -e KUBERNETES_VERSION=$(KUBERNETES_VERSION) $(BUILD_CONTAINER_NAME) bash -c /cinder/scripts/build.sh
+	docker exec \
+		-e KUBERNETES_VERSION=$(KUBERNETES_VERSION) \
+		-e MACHINE_API_VERSION=$(MACHINE_API_VERSION) \
+		-e MACHINE_API_PROVIDER_DOCKER_VERSION=$(MACHINE_API_PROVIDER_DOCKER_VERSION) \
+		$(BUILD_CONTAINER_NAME) bash -c /cinder/scripts/build.sh
 	for f in $$(find files/ -type f)
 	do
 	    docker cp $$f $(BUILD_CONTAINER_NAME):$${f##*files/}

--- a/build/images/node/scripts/build.sh
+++ b/build/images/node/scripts/build.sh
@@ -12,6 +12,9 @@ curl -L https://storage.googleapis.com/kubernetes-release/release/v${KUBERNETES_
 chmod +x /usr/bin/kubelet
 echo "KUBELET_EXTRA_ARGS=--fail-swap-on=false" >> /etc/default/kubelet
 curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
+mkdir -p /cinder/manifests
+curl -L https://github.com/criticalstack/machine-api/releases/download/v${MACHINE_API_VERSION}/machine-api.yaml -o /cinder/manifests/machine-api.yaml
+curl -L https://github.com/criticalstack/machine-api-provider-docker/releases/download/v${MACHINE_API_PROVIDER_DOCKER_VERSION}/machine-api-provider-docker.yaml -o /cinder/manifests/machine-api-provider-docker.yaml
 curl -LO https://download.docker.com/linux/static/stable/x86_64/docker-19.03.1.tgz
 tar zxvf docker-19.03.1.tgz --strip 1 -C /usr/bin docker/docker
 rm docker-19.03.1.tgz

--- a/build/images/node/scripts/install-machine-api.sh
+++ b/build/images/node/scripts/install-machine-api.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 kubectl create namespace mapi-system
-helm install machine-api /cinder/charts/machine-api.tgz --namespace mapi-system \
-    --set externalReadyWait=1s
+kubectl apply -n mapi-system -f /cinder/manifests/machine-api.yaml
 kubectl create namespace mapd-system
-helm install machine-api-provider-docker /cinder/charts/machine-api-provider-docker.tgz --namespace mapd-system
+kubectl apply -n mapd-system -f /cinder/manifests/machine-api-provider-docker.yaml

--- a/internal/cinder/config/constants/constants.go
+++ b/internal/cinder/config/constants/constants.go
@@ -7,12 +7,12 @@ import (
 )
 
 const (
-	DefaultNodeImage  = "criticalstack/cinder:v1.0.3"
+	DefaultNodeImage  = "criticalstack/cinder:v1"
 	DefaultNetwork    = "cinder"
 	KubernetesVersion = "1.18.5"
 
-	DefaultMachineAPIVersion               = "0.1.2"
-	DefaultMachineAPIProviderDockerVersion = "0.1.2"
+	DefaultMachineAPIVersion               = "1.0.1"
+	DefaultMachineAPIProviderDockerVersion = "1.0.2"
 	DefaultKubeRBACProxyVersion            = "0.5.0"
 	DefaultCiliumVersion                   = "1.8.1"
 	DefaultCiliumStartupScriptVersion      = "af2a99046eca96c0138551393b21a5c044c7fe79"
@@ -33,8 +33,8 @@ func GetImages() map[string]string {
 		"coredns":                     fmt.Sprintf("%s:%s", constants.CoreDNSImage, constants.DefaultCoreDNSVersion),
 		"bootstrap-server":            fmt.Sprintf("%s:v%s", constants.CritBootstrapServerImage, constants.DefaultBootstrapServerVersion),
 		"healthcheck-proxy":           fmt.Sprintf("%s:v%s", constants.CritHealthCheckProxyImage, constants.DefaultHealthcheckProxyVersion),
-		"machine-api":                 fmt.Sprintf("cscr.io/criticalstack/machine-api:v%s", DefaultMachineAPIVersion),
-		"machine-api-provider-docker": fmt.Sprintf("cscr.io/criticalstack/machine-api-provider-docker:v%s", DefaultMachineAPIProviderDockerVersion),
+		"machine-api":                 fmt.Sprintf("docker.io/criticalstack/machine-api:v%s", DefaultMachineAPIVersion),
+		"machine-api-provider-docker": fmt.Sprintf("docker.io/criticalstack/machine-api-provider-docker:v%s", DefaultMachineAPIProviderDockerVersion),
 		"kube-rbac-proxy":             fmt.Sprintf("gcr.io/kubebuilder/kube-rbac-proxy:v%s", DefaultKubeRBACProxyVersion),
 		"cilium":                      fmt.Sprintf("docker.io/cilium/cilium:v%s", DefaultCiliumVersion),
 		"cilium-operator-generic":     fmt.Sprintf("docker.io/cilium/operator-generic:v%s", DefaultCiliumVersion),


### PR DESCRIPTION
Rather than a Helm chart, these are now installed via the GitHub release manifests.