### PR TITLE
Update Krustlet to v0.5.0

### DIFF
--- a/build/images/node/Makefile
+++ b/build/images/node/Makefile
@@ -1,8 +1,5 @@
 .DEFAULT_GOAL:=help
 
-SHELL:=/bin/bash
-.ONESHELL:
-
 ##@ Building
 
 BIN_DIR := bin
@@ -24,14 +21,14 @@ IMAGE ?= docker.io/criticalstack/cinder:$(TAG)
 BUILD_DIR             := $(PWD)/build
 BUILD_CONTAINER_NAME  := cinder-build
 BASE_IMAGE            := docker.io/kindest/base:v20200709-8b878ace
-KUBERNETES_VERSION    := 1.18.5
+KUBERNETES_VERSION    := 1.18.10
 
 # charts
 CHARTS_DIR                          := $(PWD)/charts
-CILIUM_VERSION                      := 1.8.1
+CILIUM_VERSION                      := 1.8.5
 LOCAL_PATH_PROVISIONER_VERSION      := 0.0.12
-MACHINE_API_VERSION                 := 1.0.2
-MACHINE_API_PROVIDER_DOCKER_VERSION := 1.0.2
+MACHINE_API_VERSION                 := 1.0.6
+MACHINE_API_PROVIDER_DOCKER_VERSION := 1.0.7
 
 charts/*.tgz:
 	mkdir -p $(CHARTS_DIR)
@@ -49,11 +46,11 @@ charts/*.tgz:
 
 build/*.tar:
 	mkdir -p $(BUILD_DIR)
-	for image in $$($(CINDER) get images)
-	do
-	    docker pull $$image
-	    filename=$$(echo $$image | sed -e 's/[^A-Za-z0-9._-]/_/g').tar
-	    docker save -o build/$$filename $$image
+	for image in $$($(CINDER) get images); \
+	do \
+	    docker pull $$image && \
+	    filename=$$(echo $$image | sed -e 's/[^A-Za-z0-9._-]/_/g').tar && \
+	    docker save -o build/$$filename $$image; \
 	done
 
 .PHONY: build
@@ -68,17 +65,17 @@ build: clean $(CRIT) $(CINDER) charts/*.tgz build/*.tar ## build cinder docker i
 		-e MACHINE_API_VERSION=$(MACHINE_API_VERSION) \
 		-e MACHINE_API_PROVIDER_DOCKER_VERSION=$(MACHINE_API_PROVIDER_DOCKER_VERSION) \
 		$(BUILD_CONTAINER_NAME) bash -c /cinder/scripts/build.sh
-	for f in $$(find files/ -type f)
-	do
-	    docker cp $$f $(BUILD_CONTAINER_NAME):$${f##*files/}
+	for f in $$(find files/ -type f); \
+	do \
+	    docker cp $$f $(BUILD_CONTAINER_NAME):"$${f##*files/}"; \
 	done
 	docker cp ./bin/crit $(BUILD_CONTAINER_NAME):/usr/bin/
 	docker cp ./bin/cinder $(BUILD_CONTAINER_NAME):/usr/bin/
 	docker cp ../../../templates/audit-policy.yaml $(BUILD_CONTAINER_NAME):/etc/kubernetes/audit-policy.yaml
 	docker exec $(BUILD_CONTAINER_NAME) bash -c 'nohup containerd > /dev/null 2>&1 &'
-	for f in $$(find build/ -name '*.tar')
-	do
-	    docker exec $(BUILD_CONTAINER_NAME) ctr --namespace=k8s.io images import --all-platforms --no-unpack /build/$${f##*build/}
+	for f in $$(find build/ -name '*.tar'); \
+	do \
+	    docker exec $(BUILD_CONTAINER_NAME) ctr --namespace=k8s.io images import --all-platforms --no-unpack "/build/$${f##*build/}"; \
 	done
 	docker exec $(BUILD_CONTAINER_NAME) pkill containerd
 	docker commit --change 'ENTRYPOINT [ "/usr/local/bin/entrypoint", "/sbin/init" ]' $(BUILD_CONTAINER_NAME) $(IMAGE)

--- a/build/images/node/scripts/build.sh
+++ b/build/images/node/scripts/build.sh
@@ -18,9 +18,9 @@ curl -L https://github.com/criticalstack/machine-api-provider-docker/releases/do
 curl -LO https://download.docker.com/linux/static/stable/x86_64/docker-19.03.1.tgz
 tar zxvf docker-19.03.1.tgz --strip 1 -C /usr/bin docker/docker
 rm docker-19.03.1.tgz
-curl -LO https://krustlet.blob.core.windows.net/releases/krustlet-v0.3.0-linux-amd64.tar.gz
-tar zxvf krustlet-v0.3.0-linux-amd64.tar.gz -C /usr/bin
-rm krustlet-v0.3.0-linux-amd64.tar.gz
+curl -LO https://krustlet.blob.core.windows.net/releases/krustlet-v0.5.0-linux-amd64.tar.gz
+tar zxvf krustlet-v0.5.0-linux-amd64.tar.gz -C /usr/bin
+rm krustlet-v0.5.0-linux-amd64.tar.gz
 mkdir -p /var/lib/krustlet
 mkdir -p /etc/kubernetes/pki
 mkdir -p /kind

--- a/cmd/cinder/app/create/cluster/cluster.go
+++ b/cmd/cinder/app/create/cluster/cluster.go
@@ -206,10 +206,10 @@ func NewCommand() *cobra.Command {
 
 			if feature.Gates.Enabled(feature.Krustlet) {
 				if err := utils.NewStep("Installing Krustlet", ":fire:", opts.Verbose, func() (err error) {
-					if err := cluster.BootstrapKrustlet(opts.Name, "wasi", 3000, node); err != nil {
+					if err := cluster.BootstrapKrustlet(opts.Name, "wasi", 3000, node, cfg.RegistryMirrors); err != nil {
 						return err
 					}
-					if err := cluster.BootstrapKrustlet(opts.Name, "wascc", 3001, node); err != nil {
+					if err := cluster.BootstrapKrustlet(opts.Name, "wascc", 3001, node, cfg.RegistryMirrors); err != nil {
 						return err
 					}
 					return nil

--- a/docs/src/cinder-guide/features.md
+++ b/docs/src/cinder-guide/features.md
@@ -2,12 +2,74 @@
 
 ## Side-loading Images
 
-## Krustlet
+Kind allows you to [side-load images](https://kind.sigs.k8s.io/docs/user/quick-start/#loading-an-image-into-your-cluster) in your local clusters. Cinder exposes the same functionality via [`cinder load`](../cinder-commands/cinder-load.md):
+
+```sh
+cinder load criticalstack/quake-kube:v1.0.5
+```
+
+This will make the `criticalstack/quake-kube:v1.0.5` image from the host available in the Cinder node. Any image that is available on the host can be loaded, and Cinder lazily pulls images that are not found on the host.
+
+## Registry Mirrors
+
+Mirrors for container image registries can be setup to effectively "alias" them. The key is the alias, and the value is the full endpoint for the registry:
+
+```yaml
+apiVersion: cinder.crit.sh/v1alpha1
+kind: ClusterConfiguration
+registryMirrors:
+  docker.io: "https://docker.io"
+```
+
+It can be used to alias registries with different names OR it can be used to specify plain http registries:
+
+```yaml
+...
+registryMirrors:
+  myregistry.dev: "http://myregistry.dev"
+```
+
+## Local Registry
+
+An instance of [Distribution](https://github.com/docker/distribution) (aka Docker Registry v2) can be setup for a Cinder cluster by specifying a config file with the `LocalRegistry` feature gate:
 
 ```yaml
 apiVersion: cinder.crit.sh/v1alpha1
 kind: ClusterConfiguration
 featureGates:
+  LocalRegistry: true
+```
+
+This will start a Docker container on the host with the running registry (if not already running). The registry is shared for all Cinder clusters on a host and is available at `localhost:5000` (i.e. this is what you `docker push` to). This registry is then available inside the cluster at `cinderegg:5000`.
+
+Cinder also creates the `local-registry-hosting` ConfigMap so that any tooling that supports Local Registry Hosting, such as [Tilt](https://tilt.dev/), will be able to automatically discover and use the local registry.
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: local-registry-hosting
+  namespace: kube-public
+data:
+  localRegistryHosting.v1: |
+    host: "localhost:{{ .LocalRegistryPort }}"
+    hostFromContainerRuntime: "{{ .LocalRegistryName }}:{{ .LocalRegistryPort }}"
+    hostFromClusterNetwork: "{{ .LocalRegistryName }}:{{ .LocalRegistryPort }}"
+    help: "https://docs.crit.sh/cinder-guide/local-registry.html"`
+```
+
+More information about this Kubernetes standard can be found [here](https://github.com/kubernetes/enhancements/blob/c5b6b632811c21ababa9e3565766b2d70614feec/keps/sig-cluster-lifecycle/generic/1755-communicating-a-local-registry/README.md#design-details).
+
+## Krustlet
+
+[Krustlet](https://github.com/deislabs/krustlet) is a tool to run WebAssembly workloads natively on Kubernetes by acting like node in your Kubernetes cluster. It can be enabled for a Cinder cluster using the following configuration:
+
+
+```yaml
+apiVersion: cinder.crit.sh/v1alpha1
+kind: ClusterConfiguration
+featureGates:
+  LocalRegistry: true
   Krustlet: true
 controlPlaneConfiguration:
   kubeProxy:
@@ -21,38 +83,80 @@ controlPlaneConfiguration:
                 values: ["wasm32-wasi", "wasm32-wascc"]
 ```
 
-https://github.com/deislabs/krustlet
+*Note that node affinity is being set for `kube-proxy` to ensure it does not try to schedule a pod on either the WASI or WASCC nodes*
 
-## Local Registry
+This will start two instances of Krustlet for both [WASI](https://wasi.dev/) and [waSCC](https://wascc.dev/) runtimes:
 
-```yaml
-apiVersion: cinder.crit.sh/v1alpha1
-kind: ClusterConfiguration
-featureGates:
-  LocalRegistry: true
+```sh
+$ kubectl get no
+
+NAME           STATUS   ROLES    AGE   VERSION
+cinder         Ready    master   2m    v1.18.5
+cinder-wascc   Ready    <none>   1m    0.5.0
+cinder-wasi    Ready    <none>   1m    0.5.0
 ```
 
-const LocalRegistryHostingConfigMap = `apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: local-registry-hosting
-  namespace: kube-public
-data:
-  localRegistryHosting.v1: |
-    host: "localhost:{{ .LocalRegistryPort }}"
-    hostFromContainerRuntime: "{{ .LocalRegistryName }}:{{ .LocalRegistryPort }}"
-    hostFromClusterNetwork: "{{ .LocalRegistryName }}:{{ .LocalRegistryPort }}"
-    help: "https://docs.crit.sh/cinder-guide/local-registry.html"`
+With these nodes ready, we can build and push images to our local registry and run them on our Cinder cluster. For example, the [Hello World Rust for WASI](https://github.com/deislabs/krustlet/tree/master/demos/wasi/hello-world-rust) can be built using cargo and pushed to our local registry using [wasm-to-oci](https://github.com/engineerd/wasm-to-oci):
 
-https://github.com/kubernetes/enhancements/pull/1757
+```sh
+cargo build --target wasm32-wasi --release
+wasm-to-oci push --use-http \
+    target/wasm32-wasi/release/hello-world-rust.wasm \
+    localhost:5000/hello-world-rust:v0.2.0
+```
 
-https://github.com/kubernetes/enhancements/blob/c5b6b632811c21ababa9e3565766b2d70614feec/keps/sig-cluster-lifecycle/generic/1755-communicating-a-local-registry/README.md#design-details
+The line in [k8s.yaml](https://github.com/deislabs/krustlet/blob/v0.5.0/demos/wasi/hello-world-rust/k8s.yaml) specifying the image to use will need to be modified:
 
-## Registry Mirrors
+```
+...
+spec:
+  containers:
+    - name: hello-world-wasi-rust
+      #image: webassembly.azurecr.io/hello-world-wasi-rust:v0.2.0
+      image: cinderegg:5000/hello-world-rust:v0.2.0
+...
+```
 
-```yaml
-apiVersion: cinder.crit.sh/v1alpha1
-kind: ClusterConfiguration
-registryMirrors:
-  docker.io: "https://docker.io"
+Finally, the manifest can be applied:
+
+```sh
+kubectl apply -f k8s.yaml
+```
+
+Which will result in the pod being scheduled on the waSCC Krustlet:
+
+```
+$ kubectl get po -A
+
+NAMESPACE            NAME                                  READY   STATUS                          RESTARTS   AGE
+kube-system          cilium-operator-657978fb5b-frrxj      1/1     Running                         0          8m4s
+kube-system          cilium-pqmsc                          1/1     Running                         0          8m4s
+kube-system          coredns-pqljz                         1/1     Running                         0          7m57s
+kube-system          hello-world-wasi-rust                 0/1     ExitCode:0                      0          1s
+kube-system          kube-apiserver-cinder                 1/1     Running                         0          8m18s
+kube-system          kube-controller-manager-cinder        1/1     Running                         0          8m18s
+kube-system          kube-proxy-85lwd                      1/1     Running                         0          8m4s
+kube-system          kube-scheduler-cinder                 1/1     Running                         0          8m18s
+local-path-storage   local-path-storage-74cd8967f5-vv2mb   1/1     Running                         0          8m4s
+```
+
+And should produce the following log output:
+
+```sh
+$ kubectl logs hello-world-wasi-rust
+
+hello from stdout!
+hello from stderr!
+POD_NAME=hello-world-wasi-rust
+FOO=bar
+CONFIG_MAP_VAL=cool stuff
+Args are: []
+
+Bacon ipsum dolor amet chuck turducken porchetta, tri-tip spare ribs t-bone ham hock. Meatloaf
+pork belly leberkas, ham beef pig corned beef boudin ground round meatball alcatra jerky.
+Pancetta brisket pastrami, flank pork chop ball tip short loin burgdoggen. Tri-tip kevin
+shoulder cow andouille. Prosciutto chislic cupim, short ribs venison jerky beef ribs ham hock
+short loin fatback. Bresaola meatloaf capicola pancetta, prosciutto chicken landjaeger andouille
+swine kielbasa drumstick cupim tenderloin chuck shank. Flank jowl leberkas turducken ham tongue
+beef ribs shankle meatloaf drumstick pork t-bone frankfurter tri-tip.
 ```

--- a/internal/cinder/config/constants/constants.go
+++ b/internal/cinder/config/constants/constants.go
@@ -9,12 +9,12 @@ import (
 const (
 	DefaultNodeImage  = "criticalstack/cinder:v1"
 	DefaultNetwork    = "cinder"
-	KubernetesVersion = "1.18.5"
+	KubernetesVersion = "1.18.10"
 
-	DefaultMachineAPIVersion               = "1.0.2"
-	DefaultMachineAPIProviderDockerVersion = "1.0.2"
+	DefaultMachineAPIVersion               = "1.0.6"
+	DefaultMachineAPIProviderDockerVersion = "1.0.7"
 	DefaultKubeRBACProxyVersion            = "0.5.0"
-	DefaultCiliumVersion                   = "1.8.1"
+	DefaultCiliumVersion                   = "1.8.5"
 	DefaultCiliumStartupScriptVersion      = "af2a99046eca96c0138551393b21a5c044c7fe79"
 	DefaultLocalPathProvisionerVersion     = "0.0.12"
 	DefaultRegistryVersion                 = "2.7.1"


### PR DESCRIPTION
This updates the version of Krustlet to v0.5.0, which allows use of insecure/plain-http registries, and adds any registry mirror that is http to the insecure registries (including the Cinder local registry).