### PR TITLE
Custom labels

### DIFF
--- a/pkg/cluster/components/apiserver.go
+++ b/pkg/cluster/components/apiserver.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -212,5 +213,10 @@ func NewAPIServerStaticPod(cfg *config.ControlPlaneConfiguration) (*corev1.Pod, 
 	if err := appendExtraVolumes(p, cfg.KubeAPIServerConfiguration.ExtraVolumes); err != nil {
 		return nil, err
 	}
+
+	if err := appendExtraLabels(p, cfg.KubeAPIServerConfiguration.ExtraLabels); err != nil {
+		log.Info("apiserver extra labels", zap.Error(err))
+	}
+
 	return p, nil
 }

--- a/pkg/cluster/components/apiserver.go
+++ b/pkg/cluster/components/apiserver.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -214,9 +213,7 @@ func NewAPIServerStaticPod(cfg *config.ControlPlaneConfiguration) (*corev1.Pod, 
 		return nil, err
 	}
 
-	if err := appendExtraLabels(p, cfg.KubeAPIServerConfiguration.ExtraLabels); err != nil {
-		log.Info("apiserver extra labels", zap.Error(err))
-	}
+	appendExtraLabels(p, cfg.KubeAPIServerConfiguration.ExtraLabels)
 
 	return p, nil
 }

--- a/pkg/cluster/components/components.go
+++ b/pkg/cluster/components/components.go
@@ -83,3 +83,10 @@ func getCACertsExtraVolumes() []corev1.Volume {
 	}
 	return volumes
 }
+
+func appendExtraLabels(p *corev1.Pod, labels map[string]string) (err error) {
+	for k, v := range labels {
+		p.ObjectMeta.Labels[k] = v
+	}
+	return nil
+}

--- a/pkg/cluster/components/components.go
+++ b/pkg/cluster/components/components.go
@@ -40,6 +40,12 @@ func appendExtraVolumes(p *corev1.Pod, volumes []computil.HostPathMount) (err er
 	return nil
 }
 
+func appendExtraLabels(p *corev1.Pod, labels map[string]string) {
+	for k, v := range labels {
+		p.ObjectMeta.Labels[k] = v
+	}
+}
+
 // caCertsExtraVolumePaths specifies the paths that can be conditionally mounted into the apiserver and controller-manager containers
 // as /etc/ssl/certs might be or contain a symlink to them. It's a variable since it may be changed in unit testing. This var MUST
 // NOT be changed in normal codepaths during runtime.
@@ -82,11 +88,4 @@ func getCACertsExtraVolumes() []corev1.Volume {
 		})
 	}
 	return volumes
-}
-
-func appendExtraLabels(p *corev1.Pod, labels map[string]string) (err error) {
-	for k, v := range labels {
-		p.ObjectMeta.Labels[k] = v
-	}
-	return nil
 }

--- a/pkg/cluster/components/controllermanager.go
+++ b/pkg/cluster/components/controllermanager.go
@@ -205,9 +205,7 @@ func NewControllerManagerStaticPod(cfg *config.ControlPlaneConfiguration) *corev
 		log.Debug("controller manager extra volumes", zap.Error(err))
 	}
 
-	if err := appendExtraLabels(p, cfg.KubeControllerManagerConfiguration.ExtraLabels); err != nil {
-		log.Info("controller manager extra labels", zap.Error(err))
-	}
+	appendExtraLabels(p, cfg.KubeControllerManagerConfiguration.ExtraLabels)
 
 	return p
 }

--- a/pkg/cluster/components/controllermanager.go
+++ b/pkg/cluster/components/controllermanager.go
@@ -204,5 +204,10 @@ func NewControllerManagerStaticPod(cfg *config.ControlPlaneConfiguration) *corev
 	if err := appendExtraVolumes(p, cfg.KubeControllerManagerConfiguration.ExtraVolumes); err != nil {
 		log.Debug("controller manager extra volumes", zap.Error(err))
 	}
+
+	if err := appendExtraLabels(p, cfg.KubeControllerManagerConfiguration.ExtraLabels); err != nil {
+		log.Info("controller manager extra labels", zap.Error(err))
+	}
+
 	return p
 }

--- a/pkg/cluster/components/scheduler.go
+++ b/pkg/cluster/components/scheduler.go
@@ -106,5 +106,9 @@ func NewSchedulerStaticPod(cfg *config.ControlPlaneConfiguration) *corev1.Pod {
 	if err := appendExtraVolumes(p, cfg.KubeSchedulerConfiguration.ExtraVolumes); err != nil {
 		log.Debug("scheduler extra volumes", zap.Error(err))
 	}
+
+	if err := appendExtraLabels(p, cfg.KubeSchedulerConfiguration.ExtraLabels); err != nil {
+		log.Info("scheduler extra labels", zap.Error(err))
+	}
 	return p
 }

--- a/pkg/cluster/components/scheduler.go
+++ b/pkg/cluster/components/scheduler.go
@@ -107,8 +107,7 @@ func NewSchedulerStaticPod(cfg *config.ControlPlaneConfiguration) *corev1.Pod {
 		log.Debug("scheduler extra volumes", zap.Error(err))
 	}
 
-	if err := appendExtraLabels(p, cfg.KubeSchedulerConfiguration.ExtraLabels); err != nil {
-		log.Info("scheduler extra labels", zap.Error(err))
-	}
+	appendExtraLabels(p, cfg.KubeSchedulerConfiguration.ExtraLabels)
+
 	return p
 }

--- a/pkg/config/v1alpha1/types.go
+++ b/pkg/config/v1alpha1/types.go
@@ -143,18 +143,21 @@ type KubeAPIServerConfiguration struct {
 	ExtraVolumes []HostPathMount   `json:"extraVolumes,omitempty"`
 	FeatureGates map[string]bool   `json:"featureGates,omitempty"`
 	ExtraSANs    []string          `json:"extraSans,omitempty"`
+	ExtraLabels  map[string]string `json:"extraLabels,omitempty"`
 }
 
 type KubeControllerManagerConfiguration struct {
 	ExtraArgs    map[string]string `json:"extraArgs,omitempty"`
 	ExtraVolumes []HostPathMount   `json:"extraVolumes,omitempty"`
 	FeatureGates map[string]bool   `json:"featureGates,omitempty"`
+	ExtraLabels  map[string]string `json:"extraLabels,omitempty"`
 }
 
 type KubeSchedulerConfiguration struct {
 	ExtraArgs    map[string]string `json:"extraArgs,omitempty"`
 	ExtraVolumes []HostPathMount   `json:"extraVolumes,omitempty"`
 	FeatureGates map[string]bool   `json:"featureGates,omitempty"`
+	ExtraLabels  map[string]string `json:"extraLabels,omitempty"`
 }
 
 // APIEndpoint represents a reachable Kubernetes API endpoint.

--- a/pkg/config/v1alpha2/types.go
+++ b/pkg/config/v1alpha2/types.go
@@ -192,18 +192,21 @@ type KubeAPIServerConfiguration struct {
 	ExtraSANs                []string                 `json:"extraSans,omitempty"`
 	HealthcheckProxyVersion  string                   `json:"healthcheckProxyVersion,omitempty"`
 	HealthcheckProxyBindPort int                      `json:"healthcheckProxyBindPort,omitempty"`
+	ExtraLabels              map[string]string        `json:"extraLabels,omitempty"`
 }
 
 type KubeControllerManagerConfiguration struct {
 	ExtraArgs    map[string]string        `json:"extraArgs,omitempty"`
 	ExtraVolumes []computil.HostPathMount `json:"extraVolumes,omitempty"`
 	FeatureGates map[string]bool          `json:"featureGates,omitempty"`
+	ExtraLabels  map[string]string        `json:"extraLabels,omitempty"`
 }
 
 type KubeSchedulerConfiguration struct {
 	ExtraArgs    map[string]string        `json:"extraArgs,omitempty"`
 	ExtraVolumes []computil.HostPathMount `json:"extraVolumes,omitempty"`
 	FeatureGates map[string]bool          `json:"featureGates,omitempty"`
+	ExtraLabels  map[string]string        `json:"extraLabels,omitempty"`
 }
 
 type KubeProxyConfiguration struct {


### PR DESCRIPTION
Apologies for the PR on this repo. In the future I will open a fork and use that to PR.

This change will add the functionality to add labels to the controller manager, kube scheduler, and api-server static pods. 

Testing:
Created a local cinder cluster with the updated crit binary. Specified a config with an extra label and verified it appeared on the pod.

Milan and I also discussed potentially adding a "global" value that would apply a specific label to all static manifests. If you would like to see this functionality please let me know and I can add it before we pull this in.