### PR TITLE
Bug Fix for "crit certs renew/list" commands

### DIFF
--- a/cmd/crit/app/certs/list/list.go
+++ b/cmd/crit/app/certs/list/list.go
@@ -15,7 +15,7 @@ import (
 )
 
 var opts struct {
-	CertDir string
+	KubeDir string
 }
 
 func NewCommand() *cobra.Command {
@@ -51,7 +51,7 @@ func NewCommand() *cobra.Command {
 			}, "\t"))
 
 			for caName := range certTree {
-				ca, err := pki.LoadCertificateAuthority(opts.CertDir, caName)
+				ca, err := pki.LoadCertificateAuthority(filepath.Join(opts.KubeDir, "pki"), caName)
 				if err != nil {
 					return err
 				}
@@ -74,7 +74,7 @@ func NewCommand() *cobra.Command {
 			}, "\t"))
 			for _, certs := range certTree {
 				for _, certName := range certs {
-					cert, err := pki.ReadCertFromFile(filepath.Join(opts.CertDir, certName+".crt"))
+					cert, err := pki.ReadCertFromFile(filepath.Join(opts.KubeDir, "pki", certName+".crt"))
 					if err != nil {
 						return err
 					}
@@ -90,7 +90,7 @@ func NewCommand() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&opts.CertDir, "cert-dir", filepath.Join(constants.DefaultKubeDir, "pki"), "")
+	cmd.Flags().StringVar(&opts.KubeDir, "kube-dir", constants.DefaultKubeDir, "")
 	return cmd
 }
 

--- a/cmd/crit/app/certs/renew/renew.go
+++ b/cmd/crit/app/certs/renew/renew.go
@@ -102,6 +102,6 @@ func NewCommand() *cobra.Command {
 	}
 
 	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "")
-	cmd.Flags().StringVar(&opts.KubeDir, "kube-dir", constants.DefaultKubeDir, "")
+	cmd.Flags().StringVar(&opts.KubeDir, "kube-dir", constants.DefaultKubeDir, "renews ./*.conf and ./pki/*.crt for the specified --kube-dir")
 	return cmd
 }

--- a/cmd/crit/app/certs/renew/renew.go
+++ b/cmd/crit/app/certs/renew/renew.go
@@ -12,7 +12,7 @@ import (
 )
 
 var opts struct {
-	CertDir string
+	KubeDir string
 	DryRun  bool
 }
 
@@ -35,12 +35,12 @@ func NewCommand() *cobra.Command {
 				},
 			}
 			for caName, certs := range certTree {
-				ca, err := pki.LoadCertificateAuthority(opts.CertDir, caName)
+				ca, err := pki.LoadCertificateAuthority(filepath.Join(opts.KubeDir, "pki"), caName)
 				if err != nil {
 					return err
 				}
 				for _, certName := range certs {
-					cert, err := pki.ReadCertFromFile(filepath.Join(opts.CertDir, certName+".crt"))
+					cert, err := pki.ReadCertFromFile(filepath.Join(opts.KubeDir, "pki", certName+".crt"))
 					if err != nil {
 						return err
 					}
@@ -57,7 +57,7 @@ func NewCommand() *cobra.Command {
 						return err
 					}
 					if !opts.DryRun {
-						if err := kp.WriteFiles(opts.CertDir); err != nil {
+						if err := kp.WriteFiles(filepath.Join(opts.KubeDir, "pki")); err != nil {
 							return err
 						}
 					}
@@ -69,7 +69,7 @@ func NewCommand() *cobra.Command {
 				"scheduler.conf",
 			}
 			for _, configName := range kubeconfigs {
-				config, err := clientcmd.LoadFromFile(filepath.Join(opts.CertDir, configName))
+				config, err := clientcmd.LoadFromFile(filepath.Join(opts.KubeDir, configName))
 				if err != nil {
 					return err
 				}
@@ -77,7 +77,7 @@ func NewCommand() *cobra.Command {
 				if err != nil {
 					return err
 				}
-				ca, err := pki.LoadCertificateAuthority(opts.CertDir, "ca")
+				ca, err := pki.LoadCertificateAuthority(filepath.Join(opts.KubeDir, "pki"), "ca")
 				if err != nil {
 					return err
 				}
@@ -92,7 +92,7 @@ func NewCommand() *cobra.Command {
 				config.AuthInfos[config.Contexts[config.CurrentContext].AuthInfo].ClientCertificateData = pki.EncodeCertPEM(kp.Cert)
 				config.AuthInfos[config.Contexts[config.CurrentContext].AuthInfo].ClientKeyData = pki.MustEncodePrivateKeyPem(kp.Key)
 				if !opts.DryRun {
-					if err := kubeconfig.WriteToFile(config, filepath.Join(opts.CertDir, configName)); err != nil {
+					if err := kubeconfig.WriteToFile(config, filepath.Join(opts.KubeDir, configName)); err != nil {
 						return err
 					}
 				}
@@ -102,6 +102,6 @@ func NewCommand() *cobra.Command {
 	}
 
 	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "")
-	cmd.Flags().StringVar(&opts.CertDir, "cert-dir", filepath.Join(constants.DefaultKubeDir, "pki"), "")
+	cmd.Flags().StringVar(&opts.KubeDir, "kube-dir", constants.DefaultKubeDir, "")
 	return cmd
 }


### PR DESCRIPTION
This addresses https://github.com/criticalstack/crit/issues/14 where the `crit certs renew` command fails. 

Changes: 
* `crit certs renew`:  takes `--kube-dir` flag instead of `--cert-dir`
* `crit certs list`: the same issue was present for this command, so this now also takes the `--kube-dir` flag

Testing (locally w/ cinder): 
```
root@cinder:/# crit certs renew
root@cinder:/# crit certs renew --kube-dir /etc/kubernetes/
root@cinder:/# crit certs list
Certificate Authorities:
========================
Name		CN		Expires	NotAfter
ca		kubernetes	9y	2031-01-23T21:52:46Z
front-proxy-ca	front-proxy-ca	9y	2031-01-23T21:52:54Z

Certificates:
=============
Name				CN				Expires	NotAfter
apiserver			kube-apiserver			364d	2022-01-25T21:55:04Z
apiserver-kubelet-client	kube-apiserver-kubelet-client	364d	2022-01-25T21:55:04Z
apiserver-healthcheck-client	system:basic-info-viewer	364d	2022-01-25T21:55:05Z
front-proxy-client		front-proxy-client		364d	2022-01-25T21:55:05Z


root@cinder:/# crit certs list --kube-dir /etc/kubernetes/
Certificate Authorities:
========================
Name		CN		Expires	NotAfter
front-proxy-ca	front-proxy-ca	9y	2031-01-23T21:52:54Z
ca		kubernetes	9y	2031-01-23T21:52:46Z

Certificates:
=============
Name				CN				Expires	NotAfter
apiserver			kube-apiserver			364d	2022-01-25T21:55:04Z
apiserver-kubelet-client	kube-apiserver-kubelet-client	364d	2022-01-25T21:55:04Z
apiserver-healthcheck-client	system:basic-info-viewer	364d	2022-01-25T21:55:05Z
front-proxy-client		front-proxy-client		364d	2022-01-25T21:55:05Z

```